### PR TITLE
Bumped actions/checkout from v3.3.0 to v3.5.2

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: git checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WALL_BREW_BOT_PAT }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
         with:
           ref: ${{ github.head_ref }}
 
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Scan code
         uses: clj-holmes/clj-holmes-action@200d2d03900917d7eb3c24fc691ab83579a87fcb


### PR DESCRIPTION
Inspect dependency changes here: https://github.com/actions/checkout/blob/v3.5.2/CHANGELOG.md